### PR TITLE
CI: Update build dependencies and streamline apt operations

### DIFF
--- a/.github/workflows/template.yaml
+++ b/.github/workflows/template.yaml
@@ -37,13 +37,16 @@ env:
   REPO_NAME: example-name
   REPO_URL: https://github.com/example/example.git
   REPO_BRANCH: example-branch
-  BUILD_DEPENDS:  "ack antlr3 asciidoc autoconf automake autopoint binutils bison build-essential \
-                   bzip2 ccache cmake cpio curl device-tree-compiler fastjar flex gawk gettext gcc-multilib g++-multilib \
-                   git gperf haveged help2man intltool libc6-dev-i386 libelf-dev libfuse-dev libglib2.0-dev libgmp3-dev \
-                   libltdl-dev libmpc-dev libmpfr-dev libncurses5-dev libncursesw5-dev libpython3-dev libreadline-dev \
-                   libssl-dev libtool lrzsz mkisofs msmtp ninja-build p7zip p7zip-full patch pkgconf python2.7 python3 \
-                   python3-pyelftools python3-setuptools qemu-utils rsync scons squashfs-tools subversion swig texinfo \
-                   uglifyjs upx-ucl unzip vim wget xmlto xxd zlib1g-dev clang file nano aria2"
+  BUILD_DEPENDS:  "ack antlr3 asciidoc autoconf automake autopoint bison binutils \
+                   build-essential bzip2 ccache clang-18 cmake cpio curl device-tree-compiler ecj \
+                   fakeroot fastjar flex gawk genisoimage gettext git golang-1.23-go gnutls-dev gperf \
+                   haveged help2man intltool jq libclang-18-dev libc6-dev-i386 libelf-dev libgmp3-dev \
+                   libglib2.0-dev liblld-18-dev libltdl-dev libmpc-dev libmpfr-dev libncurses-dev \
+                   libpython3-dev libreadline-dev libssl-dev libtool libyaml-dev libz-dev lld-18 llvm-18 \
+                   lrzsz msmtp nano ninja-build p7zip p7zip-full patch pkgconf python3 python3-cryptography \
+                   python3-docutils python3-pip python3-ply python3-pyelftools qemu-utils quilt re2c rsync \
+                   scons sharutils squashfs-tools subversion swig texinfo uglifyjs unzip vim wget xmlto \
+                   xxd zlib1g-dev zstd"
   # CONFIG_FILE is the name of your own config files for compiling, you should upload these files into the root 
   # directory of your workflow repo.
   CONFIG_FILE: example.config
@@ -119,11 +122,10 @@ jobs:
         env:
           DEBIAN_FRONTEND: noninteractive
         run: |
-          sudo rm -rf /etc/apt/sources.list.d/*
-          sudo -E apt-get -qq update
-          sudo -E apt-get -qq install $BUILD_DEPENDS
-          sudo -E apt-get -qq autoremove --purge
-          sudo -E apt-get -qq clean
+          sudo -E apt -qq update
+          sudo -E apt -qq install $BUILD_DEPENDS
+          sudo -E apt -qq autoremove --purge
+          sudo -E apt -qq clean
           sudo timedatectl set-timezone $TIME_ZONE
           sudo mkdir -p /workdir/
           sudo chown $USER:$GROUPS /workdir/


### PR DESCRIPTION
Refreshed build dependencies in template.yaml for OpenWrt 24.10.
Replaced `apt-get` with `apt` for faster, modern package management.
Retained custom repositories by removing the step that cleared /etc/apt/sources.list.d/*.